### PR TITLE
Refactor: Replace video player on step2 page

### DIFF
--- a/step2/index.html
+++ b/step2/index.html
@@ -710,19 +710,7 @@
                                         data-id="6674a49" data-element_type="container">
                                         <div class="elementor-element elementor-element-3d789531 elementor-widget elementor-widget-html" data-id="3d789531" data-element_type="widget" data-widget_type="html.default">
                                                      <div class="elementor-widget-container">
-                                                        <div id="vid_66b3dca17f2b22000bd6f1c5"
-                                                                style="position: relative; width: 100%; padding: 56.60377358490566% 0 0;">
-                                                                <img decoding="async"
-                                                                        id="thumb_66b3dca17f2b22000bd6f1c5"
-                                                                        src="https://images.converteai.net/d331dfa7-f65a-427e-934f-2c0eb96fde35/players/66b3dca17f2b22000bd6f1c5/thumbnail.jpg"
-                                                                        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block;"
-                                                                        alt="thumbnail">
-                                                                <div id="backdrop_66b3dca17f2b22000bd6f1c5"
-                                                                        style=" -webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); position: absolute; top: 0; height: 100%; width: 100%; ">
-                                                                </div>
-                                                        </div>
-                                                        <script type="text/javascript"
-                                                                id="scr_66b3dca17f2b22000bd6f1c5"> var s = document.createElement("script"); s.src = "https://scripts.converteai.net/d331dfa7-f65a-427e-934f-2c0eb96fde35/players/66b3dca17f2b22000bd6f1c5/player.js", s.async = !0, document.head.appendChild(s); </script>
+<vturb-smartplayer id="vid-6823992cce914184b0c3eccf" style="display: block; margin: 0 auto; width: 100%; max-width: 400px;"></vturb-smartplayer> <script type="text/javascript"> var s=document.createElement("script"); s.src="https://scripts.converteai.net/afe361de-d52c-4970-970c-977eb531f274/players/6823992cce914184b0c3eccf/v4/player.js", s.async=!0,document.head.appendChild(s); </script>
                                                         <style>
                                                                 .elementor-element:has(#smartplayer) {
                                                                         width: 100%;


### PR DESCRIPTION
I replaced the existing video player in `step2/index.html` with a new vturb-smartplayer.

The old video embed (div with ID vid_66b3dca17f2b22000bd6f1c5 and its script) was removed. I inserted the new video player code in its place.

The new player includes inline styles `display: block; margin: 0 auto; width: 100%; max-width: 400px;` which should ensure it does not overlap with content below it.